### PR TITLE
add spotify batch modules

### DIFF
--- a/clients/spotify/src/main/kotlin/com/songspy/clients/spotify/SpotifyClient.kt
+++ b/clients/spotify/src/main/kotlin/com/songspy/clients/spotify/SpotifyClient.kt
@@ -1,6 +1,6 @@
 package com.songspy.clients.spotify
 
-import com.songspy.clients.spotify.response.PlayingTrackItemResponseDto
+import com.songspy.clients.spotify.response.PlayingTrackResponseDto
 import com.songspy.commons.extension.bearerAuth
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -11,12 +11,12 @@ class SpotifyClient(
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    fun getCurrentlyPlayingTrack(token: String): Result<PlayingTrackItemResponseDto> {
+    fun getCurrentlyPlayingTrack(token: String): Result<PlayingTrackResponseDto> {
         logger.info("[currently playing track] token: $token")
         return runCatching {
             spotifyApi.getCurrentlyPlayingTrack(
                 auth = bearerAuth(token)
-            ).item
+            )
         }
     }
 }

--- a/clients/spotify/src/main/kotlin/com/songspy/clients/spotify/oauth/SpotifyOAuthApi.kt
+++ b/clients/spotify/src/main/kotlin/com/songspy/clients/spotify/oauth/SpotifyOAuthApi.kt
@@ -1,6 +1,7 @@
 package com.songspy.clients.spotify.oauth
 
-import com.songspy.clients.spotify.response.AccessTokenResponse
+import com.songspy.clients.spotify.response.AccessTokenResponseDto
+import com.songspy.clients.spotify.response.TokenRefreshResponseDto
 import com.songspy.commons.extension.BasicAuth
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.http.MediaType
@@ -20,5 +21,16 @@ interface SpotifyOAuthApi {
         @RequestParam("grant_type") grantType: String = "authorization_code",
         @RequestParam("code") code: String,
         @RequestParam("redirect_uri") redirectUrl: String
-    ): AccessTokenResponse
+    ): AccessTokenResponseDto
+
+    @PostMapping(
+        value = ["/api/token"],
+        consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE],
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    fun refresh(
+        @RequestHeader("Authorization") auth: BasicAuth,
+        @RequestParam("grant_type") grantType: String = "refresh_token",
+        @RequestParam("refresh_token") refreshToken: String
+    ): TokenRefreshResponseDto
 }

--- a/clients/spotify/src/main/kotlin/com/songspy/clients/spotify/oauth/SpotifyOAuthClient.kt
+++ b/clients/spotify/src/main/kotlin/com/songspy/clients/spotify/oauth/SpotifyOAuthClient.kt
@@ -1,6 +1,7 @@
 package com.songspy.clients.spotify.oauth
 
-import com.songspy.clients.spotify.response.AccessTokenResponse
+import com.songspy.clients.spotify.response.AccessTokenResponseDto
+import com.songspy.clients.spotify.response.TokenRefreshResponseDto
 import com.songspy.commons.extension.basicAuth
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -18,13 +19,22 @@ class SpotifyOAuthClient(
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    fun getAccessToken(code: String): Result<AccessTokenResponse> {
+    fun getAccessToken(code: String): Result<AccessTokenResponseDto> {
         logger.info("[access token] code: $code")
         return runCatching {
             spotifyOAuthApi.getAccessToken(
                 auth = basicAuth(clientKey, secretKey),
                 code = code,
                 redirectUrl = redirectUrl
+            )
+        }
+    }
+
+    fun refresh(token: String): Result<TokenRefreshResponseDto> {
+        return runCatching {
+            spotifyOAuthApi.refresh(
+                auth = basicAuth(clientKey, secretKey),
+                refreshToken = token
             )
         }
     }

--- a/clients/spotify/src/main/kotlin/com/songspy/clients/spotify/response/AccessTokenResponseDto.kt
+++ b/clients/spotify/src/main/kotlin/com/songspy/clients/spotify/response/AccessTokenResponseDto.kt
@@ -2,7 +2,7 @@ package com.songspy.clients.spotify.response
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-data class AccessTokenResponse(
+data class AccessTokenResponseDto(
     @JsonProperty("access_token")
     val accessToken: String,
     @JsonProperty("token_type")

--- a/clients/spotify/src/main/kotlin/com/songspy/clients/spotify/response/AlbumResponseDto.kt
+++ b/clients/spotify/src/main/kotlin/com/songspy/clients/spotify/response/AlbumResponseDto.kt
@@ -1,0 +1,5 @@
+package com.songspy.clients.spotify.response
+
+data class AlbumResponseDto(
+    val images: List<ImageResponseDto>
+)

--- a/clients/spotify/src/main/kotlin/com/songspy/clients/spotify/response/ImageResponseDto.kt
+++ b/clients/spotify/src/main/kotlin/com/songspy/clients/spotify/response/ImageResponseDto.kt
@@ -1,0 +1,5 @@
+package com.songspy.clients.spotify.response
+
+data class ImageResponseDto(
+    val url: String
+)

--- a/clients/spotify/src/main/kotlin/com/songspy/clients/spotify/response/PlayingTrackItemResponseDto.kt
+++ b/clients/spotify/src/main/kotlin/com/songspy/clients/spotify/response/PlayingTrackItemResponseDto.kt
@@ -3,6 +3,7 @@ package com.songspy.clients.spotify.response
 import com.fasterxml.jackson.annotation.JsonProperty
 
 data class PlayingTrackItemResponseDto(
+    val album: AlbumResponseDto,
     val artists: List<ArtistResponseDto>,
     @JsonProperty("external_urls")
     val externalUrls: ExternalUrlResponseDto,

--- a/clients/spotify/src/main/kotlin/com/songspy/clients/spotify/response/TokenRefreshResponseDto.kt
+++ b/clients/spotify/src/main/kotlin/com/songspy/clients/spotify/response/TokenRefreshResponseDto.kt
@@ -1,0 +1,13 @@
+package com.songspy.clients.spotify.response
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class TokenRefreshResponseDto(
+    @JsonProperty("access_token")
+    val accessToken: String,
+    @JsonProperty("token_type")
+    val tokenType: String,
+    @JsonProperty("expires_in")
+    val expiresIn: Int,
+    val scope: String
+)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ rootProject.name = "songspy"
 include(
     "clients:spotify",
     "commons:extension",
+    "songspy-batch",
     "songspy-core-api",
     "storage:db-core"
 )

--- a/songspy-batch/build.gradle.kts
+++ b/songspy-batch/build.gradle.kts
@@ -1,0 +1,7 @@
+dependencies {
+    implementation(project(":clients:spotify"))
+    implementation(project(":storage:db-core"))
+
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+}

--- a/songspy-batch/src/main/kotlin/com/songspy/core/batch/configuration/ScheduleConfiguration.kt
+++ b/songspy-batch/src/main/kotlin/com/songspy/core/batch/configuration/ScheduleConfiguration.kt
@@ -1,0 +1,8 @@
+package com.songspy.core.batch.configuration
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@Configuration
+@EnableScheduling
+class ScheduleConfiguration

--- a/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/token/AccessTokenRefreshScheduler.kt
+++ b/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/token/AccessTokenRefreshScheduler.kt
@@ -1,0 +1,38 @@
+package com.songspy.core.batch.spotify.token
+
+import com.songspy.clients.spotify.oauth.SpotifyOAuthClient
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Async
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class AccessTokenRefreshScheduler(
+    private val spotifyOAuthClient: SpotifyOAuthClient,
+    private val spotifyTokenReader: SpotifyTokenReader,
+    private val spotifyTokenReNewer: SpotifyTokenReNewer
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Async
+    @Scheduled(fixedDelay = ACCESS_TOKEN_REFRESH_SCHEDULE_TIME)
+    fun schedule() {
+        logger.info("spotify access token scheduler start")
+        val expiredTokens = spotifyTokenReader.readExpired()
+        logger.info("expired token: $expiredTokens")
+        expiredTokens.forEach {
+            updateAccessTokenWithRefreshToken(it)
+        }
+    }
+
+    private fun updateAccessTokenWithRefreshToken(tokenBucket: TokenBucket) {
+        val newAccessToken = spotifyOAuthClient.refresh(tokenBucket.refreshToken)
+            .getOrThrow()
+            .accessToken
+        logger.info("token updated from ${tokenBucket.accessToken} to $newAccessToken")
+        spotifyTokenReNewer.renew(tokenBucket.id, newAccessToken)
+    }
+    companion object {
+        private const val ACCESS_TOKEN_REFRESH_SCHEDULE_TIME = 1_000L * 60 * 30 // 30분
+    }
+}

--- a/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/token/SpotifyTokenReNewer.kt
+++ b/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/token/SpotifyTokenReNewer.kt
@@ -1,0 +1,16 @@
+package com.songspy.core.batch.spotify.token
+
+import com.songspy.storage.db.core.spotify.token.TokenRepository
+import jakarta.transaction.Transactional
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+
+@Component
+class SpotifyTokenReNewer(
+    private val tokenRepository: TokenRepository
+) {
+    @Transactional
+    fun renew(id: Long, accessToken: String) {
+        tokenRepository.findByIdOrNull(id)?.renew(accessToken)
+    }
+}

--- a/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/token/SpotifyTokenReader.kt
+++ b/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/token/SpotifyTokenReader.kt
@@ -13,4 +13,9 @@ class SpotifyTokenReader(
         val tokens = tokenRepository.findAllByExpiredAtIsLessThan(LocalDateTime.now())
         return tokens.map { tokenBucketMapper.map(it) }
     }
+
+    fun readUnExpired(): List<TokenBucket> {
+        val tokens = tokenRepository.findAllByExpiredAtIsGreaterThan(LocalDateTime.now())
+        return tokens.map { tokenBucketMapper.map(it) }
+    }
 }

--- a/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/token/SpotifyTokenReader.kt
+++ b/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/token/SpotifyTokenReader.kt
@@ -1,0 +1,16 @@
+package com.songspy.core.batch.spotify.token
+
+import com.songspy.storage.db.core.spotify.token.TokenRepository
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+class SpotifyTokenReader(
+    private val tokenRepository: TokenRepository,
+    private val tokenBucketMapper: TokenBucketMapper
+) {
+    fun readExpired(): List<TokenBucket> {
+        val tokens = tokenRepository.findAllByExpiredAtIsLessThan(LocalDateTime.now())
+        return tokens.map { tokenBucketMapper.map(it) }
+    }
+}

--- a/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/token/TokenBucket.kt
+++ b/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/token/TokenBucket.kt
@@ -1,0 +1,8 @@
+package com.songspy.core.batch.spotify.token
+
+data class TokenBucket(
+    val id: Long,
+    val accessToken: String,
+    val refreshToken: String,
+    val userId: Long
+)

--- a/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/token/TokenBucketMapper.kt
+++ b/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/token/TokenBucketMapper.kt
@@ -1,0 +1,16 @@
+package com.songspy.core.batch.spotify.token
+
+import com.songspy.storage.db.core.spotify.token.TokenEntity
+import org.springframework.stereotype.Component
+
+@Component
+class TokenBucketMapper {
+    fun map(entity: TokenEntity): TokenBucket {
+        return TokenBucket(
+            id = entity.id,
+            accessToken = entity.accessToken,
+            refreshToken = entity.refreshToken,
+            userId = entity.userId
+        )
+    }
+}

--- a/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/track/CurrentPlayingTrackScheduler.kt
+++ b/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/track/CurrentPlayingTrackScheduler.kt
@@ -29,6 +29,7 @@ class CurrentPlayingTrackScheduler(
 
     private fun getAndAppendPlayingTrack(tokenBucket: TokenBucket) {
         val trackDto = spotifyClient.getCurrentlyPlayingTrack(tokenBucket.accessToken)
+            .onFailure { println(it) }
             .getOrNull()
         if (trackDto != null) {
             val currentPlayingTrack = spotifyCurrentPlayingTrackMapper.map(trackDto.item)

--- a/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/track/CurrentPlayingTrackScheduler.kt
+++ b/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/track/CurrentPlayingTrackScheduler.kt
@@ -1,0 +1,43 @@
+package com.songspy.core.batch.spotify.track
+
+import com.songspy.clients.spotify.SpotifyClient
+import com.songspy.core.batch.spotify.token.SpotifyTokenReader
+import com.songspy.core.batch.spotify.token.TokenBucket
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Async
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class CurrentPlayingTrackScheduler(
+    private val spotifyClient: SpotifyClient,
+    private val spotifyTokenReader: SpotifyTokenReader,
+    private val spotifyCurrentPlayingTrackMapper: SpotifyCurrentPlayingTrackMapper,
+    private val spotifyCurrentPlayingTrackAppender: SpotifyCurrentPlayingTrackAppender
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Async
+    @Scheduled(fixedDelay = CURRENTLY_PLAYING_TRACK__SCHEDULE_TIME)
+    fun schedule() {
+        logger.info("spotify currently playing track scheduler start")
+        val tokens = spotifyTokenReader.readUnExpired()
+        tokens.forEach {
+            getAndAppendPlayingTrack(it)
+        }
+    }
+
+    private fun getAndAppendPlayingTrack(tokenBucket: TokenBucket) {
+        val trackDto = spotifyClient.getCurrentlyPlayingTrack(tokenBucket.accessToken)
+            .getOrNull()
+        if (trackDto != null) {
+            val currentPlayingTrack = spotifyCurrentPlayingTrackMapper.map(trackDto.item)
+            spotifyCurrentPlayingTrackAppender.append(tokenBucket.userId, currentPlayingTrack)
+            logger.info("[current track append success] user: ${tokenBucket.userId} | track: $currentPlayingTrack")
+        }
+    }
+
+    companion object {
+        private const val CURRENTLY_PLAYING_TRACK__SCHEDULE_TIME = 1_000L * 60 * 3 // 3분
+    }
+}

--- a/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/track/SpotifyCurrentPlayingTrack.kt
+++ b/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/track/SpotifyCurrentPlayingTrack.kt
@@ -1,0 +1,8 @@
+package com.songspy.core.batch.spotify.track
+
+data class SpotifyCurrentPlayingTrack(
+    val title: String,
+    val artistName: String,
+    val originalUrl: String,
+    val previewUrl: String
+)

--- a/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/track/SpotifyCurrentPlayingTrack.kt
+++ b/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/track/SpotifyCurrentPlayingTrack.kt
@@ -4,5 +4,6 @@ data class SpotifyCurrentPlayingTrack(
     val title: String,
     val artistName: String,
     val originalUrl: String,
-    val previewUrl: String
+    val previewUrl: String,
+    val albumImageUrl: String
 )

--- a/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/track/SpotifyCurrentPlayingTrackAppender.kt
+++ b/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/track/SpotifyCurrentPlayingTrackAppender.kt
@@ -1,0 +1,15 @@
+package com.songspy.core.batch.spotify.track
+
+import com.songspy.storage.db.core.spotify.track.CurrentTrackRepository
+import org.springframework.stereotype.Component
+
+@Component
+class SpotifyCurrentPlayingTrackAppender(
+    private val currentTrackRepository: CurrentTrackRepository,
+    private val spotifyCurrentPlayingTrackMapper: SpotifyCurrentPlayingTrackMapper
+) {
+    fun append(userId: Long, track: SpotifyCurrentPlayingTrack) {
+        val entity = spotifyCurrentPlayingTrackMapper.map(userId, track)
+        currentTrackRepository.save(entity)
+    }
+}

--- a/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/track/SpotifyCurrentPlayingTrackMapper.kt
+++ b/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/track/SpotifyCurrentPlayingTrackMapper.kt
@@ -11,7 +11,8 @@ class SpotifyCurrentPlayingTrackMapper {
             title = dto.title,
             artistName = dto.artists.getOrNull(0)?.name ?: "",
             originalUrl = dto.externalUrls.spotify,
-            previewUrl = dto.previewUrl
+            previewUrl = dto.previewUrl,
+            albumImageUrl = dto.album.images.getOrNull(0)?.url ?: ""
         )
     }
 
@@ -21,7 +22,8 @@ class SpotifyCurrentPlayingTrackMapper {
             title = track.title,
             artistName = track.artistName,
             originalUrl = track.originalUrl,
-            previewUrl = track.previewUrl
+            previewUrl = track.previewUrl,
+            albumImageUrl = track.albumImageUrl
         )
     }
 }

--- a/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/track/SpotifyCurrentPlayingTrackMapper.kt
+++ b/songspy-batch/src/main/kotlin/com/songspy/core/batch/spotify/track/SpotifyCurrentPlayingTrackMapper.kt
@@ -1,0 +1,27 @@
+package com.songspy.core.batch.spotify.track
+
+import com.songspy.clients.spotify.response.PlayingTrackItemResponseDto
+import com.songspy.storage.db.core.spotify.track.CurrentTrackEntity
+import org.springframework.stereotype.Component
+
+@Component
+class SpotifyCurrentPlayingTrackMapper {
+    fun map(dto: PlayingTrackItemResponseDto): SpotifyCurrentPlayingTrack {
+        return SpotifyCurrentPlayingTrack(
+            title = dto.title,
+            artistName = dto.artists.getOrNull(0)?.name ?: "",
+            originalUrl = dto.externalUrls.spotify,
+            previewUrl = dto.previewUrl
+        )
+    }
+
+    fun map(userId: Long, track: SpotifyCurrentPlayingTrack): CurrentTrackEntity {
+        return CurrentTrackEntity(
+            userId = userId,
+            title = track.title,
+            artistName = track.artistName,
+            originalUrl = track.originalUrl,
+            previewUrl = track.previewUrl
+        )
+    }
+}

--- a/songspy-core-api/build.gradle.kts
+++ b/songspy-core-api/build.gradle.kts
@@ -3,6 +3,7 @@ val kotestVersion: String by project
 
 dependencies {
     implementation(project(":storage:db-core"))
+    implementation(project(":songspy-batch"))
 
     implementation("org.springframework.boot:spring-boot-starter-web")
 

--- a/songspy-core-api/src/main/resources/application.yml
+++ b/songspy-core-api/src/main/resources/application.yml
@@ -3,5 +3,5 @@ spring.application.name: songspy-core-api
 spring:
   config:
     import:
-#      - spotify.yml
+      - spotify.yml
       - db.yml

--- a/storage/db-core/src/main/kotlin/com/songspy/storage/db/core/configuration/CoreJpaConfiguration.kt
+++ b/storage/db-core/src/main/kotlin/com/songspy/storage/db/core/configuration/CoreJpaConfiguration.kt
@@ -1,0 +1,12 @@
+package com.songspy.storage.db.core.configuration
+
+import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+
+@EnableJpaAuditing
+@EntityScan("com.songspy")
+@EnableJpaRepositories("com.songspy")
+@Configuration
+class CoreJpaConfiguration

--- a/storage/db-core/src/main/kotlin/com/songspy/storage/db/core/spotify/token/TokenEntity.kt
+++ b/storage/db-core/src/main/kotlin/com/songspy/storage/db/core/spotify/token/TokenEntity.kt
@@ -7,17 +7,22 @@ import jakarta.persistence.Table
 import java.time.LocalDateTime
 
 @Entity
-@Table(name = "spotify-token")
+@Table(name = "spotify_token")
 class TokenEntity(
     @Column(name = "ref_user_id")
     val userId: Long,
 
     @Column(name = "access_token")
-    val accessToken: String,
+    var accessToken: String,
 
     @Column(name = "refresh_token")
     val refreshToken: String,
 
     @Column(name = "expired_at")
-    val expiredAt: LocalDateTime
-) : BaseEntity()
+    var expiredAt: LocalDateTime
+) : BaseEntity() {
+    fun renew(accessToken: String) {
+        this.accessToken = accessToken
+        this.expiredAt = LocalDateTime.now().plusMinutes(60)
+    }
+}

--- a/storage/db-core/src/main/kotlin/com/songspy/storage/db/core/spotify/token/TokenRepository.kt
+++ b/storage/db-core/src/main/kotlin/com/songspy/storage/db/core/spotify/token/TokenRepository.kt
@@ -1,0 +1,8 @@
+package com.songspy.storage.db.core.spotify.token
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDateTime
+
+interface TokenRepository : JpaRepository<TokenEntity, Long> {
+    fun findAllByExpiredAtIsLessThan(expiredAt: LocalDateTime): List<TokenEntity>
+}

--- a/storage/db-core/src/main/kotlin/com/songspy/storage/db/core/spotify/token/TokenRepository.kt
+++ b/storage/db-core/src/main/kotlin/com/songspy/storage/db/core/spotify/token/TokenRepository.kt
@@ -5,4 +5,6 @@ import java.time.LocalDateTime
 
 interface TokenRepository : JpaRepository<TokenEntity, Long> {
     fun findAllByExpiredAtIsLessThan(expiredAt: LocalDateTime): List<TokenEntity>
+
+    fun findAllByExpiredAtIsGreaterThan(expiredAt: LocalDateTime): List<TokenEntity>
 }

--- a/storage/db-core/src/main/kotlin/com/songspy/storage/db/core/spotify/track/CurrentTrackEntity.kt
+++ b/storage/db-core/src/main/kotlin/com/songspy/storage/db/core/spotify/track/CurrentTrackEntity.kt
@@ -21,5 +21,8 @@ class CurrentTrackEntity(
     val originalUrl: String,
 
     @Column(name = "preview_url")
-    val previewUrl: String
+    val previewUrl: String,
+
+    @Column(name = "album_image_url")
+    val albumImageUrl: String
 ) : BaseEntity()

--- a/storage/db-core/src/main/kotlin/com/songspy/storage/db/core/spotify/track/CurrentTrackEntity.kt
+++ b/storage/db-core/src/main/kotlin/com/songspy/storage/db/core/spotify/track/CurrentTrackEntity.kt
@@ -1,0 +1,25 @@
+package com.songspy.storage.db.core.spotify.track
+
+import com.songspy.storage.db.core.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "current_track")
+class CurrentTrackEntity(
+    @Column(name = "ref_user_id")
+    val userId: Long,
+
+    @Column(name = "title")
+    val title: String,
+
+    @Column(name = "artist_name")
+    val artistName: String,
+
+    @Column(name = "original_url")
+    val originalUrl: String,
+
+    @Column(name = "preview_url")
+    val previewUrl: String
+) : BaseEntity()

--- a/storage/db-core/src/main/kotlin/com/songspy/storage/db/core/spotify/track/CurrentTrackRepository.kt
+++ b/storage/db-core/src/main/kotlin/com/songspy/storage/db/core/spotify/track/CurrentTrackRepository.kt
@@ -1,0 +1,5 @@
+package com.songspy.storage.db.core.spotify.track
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CurrentTrackRepository : JpaRepository<CurrentTrackEntity, Long>


### PR DESCRIPTION
스포티파이 api를 이용해서 스케줄링을 합니다.

1. AccessTokenRefreshScheduler
	- access token을 refresh하기 위한 스케줄러입니다. 30분 간격으로 리프레시를 합니다.
2. CurrentPlayingTrackScheduler
	- 현재 곡 조회를 위한 스케줄러입니다. 3분 간격으로 access token을 통해 유저들의 현재 듣고 있는 곡을 가져옵니다.